### PR TITLE
Fix ngrok tunneling issue

### DIFF
--- a/ollama-ai/run-on-colab/ollama-ai-colab.ipynb
+++ b/ollama-ai/run-on-colab/ollama-ai-colab.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "await asyncio.gather(\n",
     "    run_process(['ollama', 'serve']),\n",
-    "    run_process(['ngrok', 'http', '--log', 'stderr', '11434']),\n",
+    "    run_process(['ngrok', 'http', '--log', 'stderr', '11434', '--host-header', 'localhost:11434'])\n",
     ")"
    ]
   },


### PR DESCRIPTION
@marcogreiveldinger thanks for the amazing video. 

I encountered that the ngrok had some tunneling issues with the command you have used here with ollama version > 1.2.8, the same was highlited in one of the issues on ollama repo as well: https://github.com/ollama/ollama/issues/3269

They have provided a fix for the same by setting `host-header` to `localhost:11434`, check here: https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-use-ollama-with-ngrok

I was able to successfully run after making required changes to include the `host-header` as suggested. Have made the required changes in the notebook with this PR, hope it helps!